### PR TITLE
Improved output formatting, with option for CSV/JSON

### DIFF
--- a/Core/Format.go
+++ b/Core/Format.go
@@ -39,7 +39,7 @@ func FormatTweetsCSV(tweets []Tweet) {
 		log.Fatal(err)
 	}
 
-	fmt.Println(string(buf.Bytes()))
+	fmt.Print(string(buf.Bytes()))
 }
 
 func FormatTweetsJSON(tweets []Tweet) {

--- a/Core/Format.go
+++ b/Core/Format.go
@@ -1,22 +1,50 @@
 package Core
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"log"
 )
 
-func FormatDefault(tweet Tweet) {
-	fmt.Printf("%d,%s,%s,%s,%s,%s\n",
-		tweet.ID,
-		tweet.URL,
-		tweet.Timestamp,
-		tweet.Username,
-		tweet.Fullname,
-		tweet.Text,
-	)
+func FormatTweets(format string, tweets []Tweet) {
+	if format == "json" {
+		FormatTweetsJSON(tweets)
+	} else {
+		FormatTweetsCSV(tweets)
+	}
 }
 
-func FormatJSON(tweet Tweet) {
-	tweetJSON, _ := json.Marshal(tweet)
-	fmt.Println(string(tweetJSON))
+func FormatTweetsCSV(tweets []Tweet) {
+	var b []byte
+	buf := bytes.NewBuffer(b)
+	w := csv.NewWriter(buf)
+
+	for _, tweet := range tweets {
+		row := []string{
+			fmt.Sprintf("%d", tweet.ID),
+			tweet.URL,
+			tweet.Timestamp,
+			tweet.Username,
+			tweet.Fullname,
+			tweet.Text,
+		}
+		if err := w.Write(row); err != nil {
+			log.Fatalln("error writing row to csv:", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(buf.Bytes()))
+}
+
+func FormatTweetsJSON(tweets []Tweet) {
+	for _, tweet := range tweets {
+		tweetJSON, _ := json.Marshal(tweet)
+		fmt.Println(string(tweetJSON))
+	}
 }

--- a/Core/Format.go
+++ b/Core/Format.go
@@ -23,7 +23,7 @@ func FormatTweetsCSV(tweets []Tweet) {
 
 	for _, tweet := range tweets {
 		row := []string{
-			fmt.Sprintf("%d", tweet.ID),
+			tweet.ID,
 			tweet.URL,
 			tweet.Timestamp,
 			tweet.Username,

--- a/Core/Format.go
+++ b/Core/Format.go
@@ -1,0 +1,22 @@
+package Core
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func FormatDefault(tweet Tweet) {
+	fmt.Printf("%d,%s,%s,%s,%s,%s\n",
+		tweet.ID,
+		tweet.URL,
+		tweet.Timestamp,
+		tweet.Username,
+		tweet.Fullname,
+		tweet.Text,
+	)
+}
+
+func FormatJSON(tweet Tweet) {
+	tweetJSON, _ := json.Marshal(tweet)
+	fmt.Println(string(tweetJSON))
+}

--- a/Core/Main.go
+++ b/Core/Main.go
@@ -4,14 +4,14 @@ import (
 	"net/url"
 )
 
-var(
+var (
 	condition bool   = true
 	cursor    string = ""
 )
 
-func Main(Query *string, Instance *string) () {
+func Main(Query *string, Instance *string, Format *string) {
 	(*Query) = url.QueryEscape(*Query)
 	for condition {
-		condition = Scrape(Request(Query, Instance, &cursor), &cursor)
+		condition = Scrape(Request(Query, Instance, &cursor), Format, &cursor)
 	}
 }

--- a/Core/Request.go
+++ b/Core/Request.go
@@ -1,18 +1,18 @@
 package Core
 
 import (
-	"io"
 	"fmt"
+	"io"
 	"log"
-	"time"
 	"net/http"
+	"time"
 )
 
 var (
-	Client *http.Client = new(http.Client);
+	Client *http.Client = new(http.Client)
 )
 
-func Request(Query *string, Instance *string, cursor *string) (io.ReadCloser) {
+func Request(Query *string, Instance *string, cursor *string) io.ReadCloser {
 	var url string = fmt.Sprintf("https://%s/search?f=tweet&q=%s", *Instance, *Query)
 	if *cursor != "" {
 		url = fmt.Sprintf("https://%s/search%s", *Instance, *cursor)

--- a/Core/Scrape.go
+++ b/Core/Scrape.go
@@ -48,6 +48,7 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 		return false
 	}
 
+	var tweets []Tweet
 	parsedWebpage.Find("div.timeline-item").Each(func(i int, t *goquery.Selection) {
 		tweet_ID_h, _ := t.Find("a").Attr("href")
 		tweet_ID_s := strings.Split(tweet_ID_h, "/")
@@ -70,13 +71,11 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 			Fullname:  tweet_fname,
 			Timestamp: tweet_TS,
 		}
-
-		if *Format == "json" {
-			FormatJSON(tweet)
-		} else {
-			FormatDefault(tweet)
-		}
+		tweets = append(tweets, tweet)
 	})
+
+	FormatTweets(*Format, tweets)
+
 	*cursor, _ = parsedWebpage.Find("div.show-more").Last().Find("a").Attr("href")
 	return true
 }

--- a/Core/Scrape.go
+++ b/Core/Scrape.go
@@ -63,15 +63,17 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 		tweet_handle := t.Find("a.username").First().Text()
 		tweet_fname := t.Find("a.fullname").First().Text()
 
-		tweet := Tweet{
-			ID:        tweet_ID,
-			URL:       tweet_URL,
-			Text:      tweet_text,
-			Username:  tweet_handle,
-			Fullname:  tweet_fname,
-			Timestamp: tweet_TS,
+		if tweet_ID != 0 {
+			tweet := Tweet{
+				ID:        tweet_ID,
+				URL:       tweet_URL,
+				Text:      tweet_text,
+				Username:  tweet_handle,
+				Fullname:  tweet_fname,
+				Timestamp: tweet_TS,
+			}
+			tweets = append(tweets, tweet)
 		}
-		tweets = append(tweets, tweet)
 	})
 
 	FormatTweets(*Format, tweets)

--- a/Core/Scrape.go
+++ b/Core/Scrape.go
@@ -11,17 +11,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-var (
-	escapeChars *strings.Replacer = strings.NewReplacer(
-		"\n", " ",
-		"\t", " ",
-		"\r", " ",
-		";", " ",
-		",", " ",
-	)
-	Webpage *goquery.Document = new(goquery.Document)
-)
-
 type Tweet struct {
 	ID        int    `json:"id"`
 	URL       string `json:"url"`
@@ -58,7 +47,7 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 
 		tweet_TS, _ := t.Find("span.tweet-date").Find("a").Attr("title")
 
-		tweet_text := escapeChars.Replace(t.Find("div.tweet-content.media-body").Text())
+		tweet_text := t.Find("div.tweet-content.media-body").Text()
 
 		tweet_handle := t.Find("a.username").First().Text()
 		tweet_fname := t.Find("a.fullname").First().Text()

--- a/Core/Scrape.go
+++ b/Core/Scrape.go
@@ -64,6 +64,10 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 		}
 	})
 
+	if len(tweets) == 0 {
+		return false
+	}
+
 	FormatTweets(*Format, tweets)
 
 	*cursor, _ = parsedWebpage.Find("div.show-more").Last().Find("a").Attr("href")

--- a/Core/Scrape.go
+++ b/Core/Scrape.go
@@ -5,14 +5,13 @@ import (
 	"io"
 	"log"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 )
 
 type Tweet struct {
-	ID        int    `json:"id"`
+	ID        string `json:"id"`
 	URL       string `json:"url"`
 	Text      string `json:"text"`
 	Username  string `json:"username"`
@@ -41,7 +40,7 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 	parsedWebpage.Find("div.timeline-item").Each(func(i int, t *goquery.Selection) {
 		tweet_ID_h, _ := t.Find("a").Attr("href")
 		tweet_ID_s := strings.Split(tweet_ID_h, "/")
-		tweet_ID, _ := strconv.Atoi(extractViaRegexp(&(tweet_ID_s[len(tweet_ID_s)-1]), `\d*`))
+		tweet_ID := extractViaRegexp(&(tweet_ID_s[len(tweet_ID_s)-1]), `\d*`)
 
 		tweet_URL := fmt.Sprintf("https://twitter.com%s", strings.Split(tweet_ID_h, "#")[0])
 
@@ -52,7 +51,7 @@ func Scrape(responseBody io.ReadCloser, Format *string, cursor *string) bool {
 		tweet_handle := t.Find("a.username").First().Text()
 		tweet_fname := t.Find("a.fullname").First().Text()
 
-		if tweet_ID != 0 {
+		if tweet_ID != "" {
 			tweet := Tweet{
 				ID:        tweet_ID,
 				URL:       tweet_URL,

--- a/InputParser/InputParser.go
+++ b/InputParser/InputParser.go
@@ -1,13 +1,14 @@
 package InputParser
 
 import (
-	"os"
 	"flag"
+	"os"
 )
 
 type Arguments struct {
 	Query    string
 	Instance string
+	Format   string
 }
 
 var arguments *Arguments = new(Arguments)
@@ -16,12 +17,18 @@ func InputParser() *Arguments {
 
 	flag.StringVar(&(arguments.Query), "Query", "", "Specify search query.")
 	flag.StringVar(&(arguments.Instance), "Instance", "nitter.nl", "Specify instance to get data from.")
-    flag.Parse()
+	flag.StringVar(&(arguments.Format), "Format", "json", "Specify the return format: csv (default), or json.")
+	flag.Parse()
 
-	if (*arguments).Query == "" { 
+	if (*arguments).Query == "" || !ValidateFormatArgument(arguments) {
 		flag.Usage()
 		os.Exit(1)
-	}	
-	
+	}
+
 	return arguments
+}
+
+func ValidateFormatArgument(arguments *Arguments) bool {
+	format := (*arguments).Format
+	return format == "" || format == "csv" || format == "json"
 }

--- a/InputParser/InputParser.go
+++ b/InputParser/InputParser.go
@@ -17,7 +17,7 @@ func InputParser() *Arguments {
 
 	flag.StringVar(&(arguments.Query), "Query", "", "Specify search query.")
 	flag.StringVar(&(arguments.Instance), "Instance", "nitter.nl", "Specify instance to get data from.")
-	flag.StringVar(&(arguments.Format), "Format", "json", "Specify the return format: csv (default), or json.")
+	flag.StringVar(&(arguments.Format), "Format", "csv", "Specify the return format: csv (default), or json.")
 	flag.Parse()
 
 	if (*arguments).Query == "" || !ValidateFormatArgument(arguments) {

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Like Twint, but zero fat.
 4) `go mod tidy`
 
 # Usage
-- Without compiling: `go run main.go -Query $QUERY -Instance $INSTANCE`
+- Without compiling: `go run main.go -Query $QUERY -Instance $INSTANCE -Format $FORMAT`
 - If you compiled... well at this point you are supposed to know.
 
 ## CLI Arguments
 1) `$QUERY`: [Here](https://github.com/igorbrigadir/twitter-advanced-search) you go.
 2) `$INSTANCE`: [Here](https://github.com/zedeus/nitter/wiki/Instances) you go.
+2) `$FORMAT`: "csv" or "json".
 
 # Questions/issues
 > Sir, the bill is: five GitHub stars, two forks and one retweet.

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"twint-lite/InputParser"
 	"twint-lite/Core"
+	"twint-lite/InputParser"
 )
 
 func main() {
 	Arguments := InputParser.InputParser()
-	Core.Main(&(Arguments.Query), &(Arguments.Instance))
+	Core.Main(&(Arguments.Query), &(Arguments.Instance), &(Arguments.Format))
 }


### PR DESCRIPTION
This PR improves the output formatting to allow users to choose for `-Format csv` or `-Format json` for improved output handling.

Default "csv" mode will output valid CSV rather than the old comma-separated format that could cause issues when dates, tweets, or user display names contained commas.

The "json" option outputs a list of JSON strings for each tweet in the format `{id, url, text, username, fullname, timestamp}`.

The IDE also did some code linting to imports and remove spacing, which I've opted to leave in.

This could be further improved by moving the `FormatTweets` function out of the `Scrape` function, but I left it working as it used to.