### PR TITLE
Simplified image URL parsing

### DIFF
--- a/Core/Main.go
+++ b/Core/Main.go
@@ -12,6 +12,6 @@ var (
 func Main(Query *string, Instance *string, Format *string) {
 	(*Query) = url.QueryEscape(*Query)
 	for condition {
-		condition = Scrape(Request(Query, Instance, &cursor), Format, &cursor)
+		condition = Scrape(Request(Query, Instance, &cursor), Instance, Format, &cursor)
 	}
 }

--- a/Core/Request.go
+++ b/Core/Request.go
@@ -17,7 +17,13 @@ func Request(Query *string, Instance *string, cursor *string) io.ReadCloser {
 	if *cursor != "" {
 		url = fmt.Sprintf("https://%s/search%s", *Instance, *cursor)
 	}
+	hlsCookie := &http.Cookie{
+		Name:   "hlsPlayback",
+		Value:  "on",
+		MaxAge: 300,
+	}
 	req, err := http.NewRequest("GET", url, nil)
+	req.AddCookie(hlsCookie)
 	if err != nil {
 		log.Fatalf("[nr] %s\n", err)
 	}


### PR DESCRIPTION
Media URLs were recently broken. They used to be converted to twimg.com URLs to avoid hitting the instance for the media. However, that was susceptible to issues if URL formats changed.

In the interest of trimming fat, this PR will just prepend the instance to get the fully-qualified URL and rely on nitter to ensure the image URL is valid.

In order to get video, we need to enable HLS playback first via a request cookie.